### PR TITLE
Refresh Failure Failthrough

### DIFF
--- a/dist/credentialprovider.js
+++ b/dist/credentialprovider.js
@@ -263,20 +263,15 @@ class CortexCredentialProvider {
         }
         let credentials = this.credentials[datalakeId];
         if (Date.now() + this.accTokenGuardTime * 1000 > credentials.validUntil * 1000) {
-            try {
-                common_1.commonLogger.info(CortexCredentialProvider, 'Asking for a new access_token');
-                let idpResponse = await this.refreshAccessToken(credentials.refreshToken);
-                credentials.accessToken = idpResponse.access_token;
-                credentials.validUntil = idpResponse.validUntil;
-                if (idpResponse.refresh_token) {
-                    credentials.refreshToken = idpResponse.refresh_token;
-                    common_1.commonLogger.info(CortexCredentialProvider, 'Received new Cortex Refresh Token');
-                }
-                await this.updateCredentialsItem(datalakeId, credentials);
+            common_1.commonLogger.info(CortexCredentialProvider, 'Asking for a new access_token');
+            let idpResponse = await this.refreshAccessToken(credentials.refreshToken);
+            credentials.accessToken = idpResponse.access_token;
+            credentials.validUntil = idpResponse.validUntil;
+            if (idpResponse.refresh_token) {
+                credentials.refreshToken = idpResponse.refresh_token;
+                common_1.commonLogger.info(CortexCredentialProvider, 'Received new Cortex Refresh Token');
             }
-            catch (_a) {
-                common_1.commonLogger.info(CortexCredentialProvider, 'Failed to get a new access token');
-            }
+            await this.updateCredentialsItem(datalakeId, credentials);
         }
         return {
             accessToken: credentials.accessToken,

--- a/lib/credentialprovider.ts
+++ b/lib/credentialprovider.ts
@@ -357,19 +357,15 @@ export abstract class CortexCredentialProvider<T, K extends keyof T> {
         }
         let credentials = this.credentials[datalakeId]
         if (Date.now() + this.accTokenGuardTime * 1000 > credentials.validUntil * 1000) {
-            try {
-                commonLogger.info(CortexCredentialProvider, 'Asking for a new access_token')
-                let idpResponse = await this.refreshAccessToken(credentials.refreshToken)
-                credentials.accessToken = idpResponse.access_token
-                credentials.validUntil = idpResponse.validUntil
-                if (idpResponse.refresh_token) {
-                    credentials.refreshToken = idpResponse.refresh_token
-                    commonLogger.info(CortexCredentialProvider, 'Received new Cortex Refresh Token')
-                }
-                await this.updateCredentialsItem(datalakeId, credentials)
-            } catch {
-                commonLogger.info(CortexCredentialProvider, 'Failed to get a new access token')
+            commonLogger.info(CortexCredentialProvider, 'Asking for a new access_token')
+            let idpResponse = await this.refreshAccessToken(credentials.refreshToken)
+            credentials.accessToken = idpResponse.access_token
+            credentials.validUntil = idpResponse.validUntil
+            if (idpResponse.refresh_token) {
+                credentials.refreshToken = idpResponse.refresh_token
+                commonLogger.info(CortexCredentialProvider, 'Received new Cortex Refresh Token')
             }
+            await this.updateCredentialsItem(datalakeId, credentials)
         }
         return {
             accessToken: credentials.accessToken,


### PR DESCRIPTION
Let the refresh error fail through (do not catch it) to allow the reason appear in the error log